### PR TITLE
Fix asset paths and close head tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Crystal Media Foundation</title>
+  </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,6 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  // Use relative paths for assets so the app can be served from any subdirectory
+  base: './',
 })


### PR DESCRIPTION
## Summary
- close `head` tag in `index.html`
- use relative paths for Vite build assets

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877845d6b4483239a13b02a0a34b63c